### PR TITLE
Add Loader=yaml.FullLoader, as pyyaml 5.1+ requires a loader definiti…

### DIFF
--- a/pyaptly/__init__.py
+++ b/pyaptly/__init__.py
@@ -784,7 +784,7 @@ def main(argv=None):
     lg.debug("Args: %s", vars(args))
 
     with codecs.open(args.config, 'r', encoding="UTF-8") as cfgfile:
-        cfg = yaml.load(cfgfile)
+        cfg = yaml.load(cfgfile, Loader=yaml.FullLoader)
     state.read()
 
     # run function for selected subparser


### PR DESCRIPTION
as pyyaml 5.1+ requires a loader definition for security purposes

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation