### PR TITLE
fix: stop forcing noarch

### DIFF
--- a/tools/venv-rpm
+++ b/tools/venv-rpm
@@ -11,7 +11,6 @@ Version:        2.0.0^{revision}
 Release:        1%{{?dist}}
 Summary:        Automates the creation and managment of aptly mirrors and snapshots based on toml input files
 License:        AGPL-3.0-or-later
-BuildArch:      noarch
 Requires:       python3.11
 
 %description
@@ -41,10 +40,6 @@ rm -rf /opt/pyaptly
 
 def main():
     os.chdir("/source")
-    macros = Path("/root/.rpmmacros")
-    with macros.open("w", encoding="UTF-8") as f:
-        f.write("%_binaries_in_noarch_packages_terminate_build   0")
-        f.write("\n")
     run(["dnf", "install", "-y", "rpm-build", "python3.11", "git"], check=True)
     date = datetime.now().strftime("%a %b %d %Y")
     build_id = run(


### PR DESCRIPTION
although it seems technically correct that the package is noarch, I decided against forcing it. It seems like nothing is gained for the risk for corrupt __pycache__ files and similar things.