### PR TITLE
fix: Don't fail if a to-be archived publish has missing snapshots

### DIFF
--- a/pyaptly/conftest.py
+++ b/pyaptly/conftest.py
@@ -147,7 +147,7 @@ def mirror_update(environment, config):
 
 @pytest.fixture()
 def snapshot_create(config, mirror_update, freeze):
-    """Test if createing snapshots works."""
+    """Test if creating snapshots works."""
     args = ["-c", config, "snapshot", "create"]
     main.main(args)
     state = state_reader.SystemStateReader()

--- a/pyaptly/main.py
+++ b/pyaptly/main.py
@@ -51,7 +51,7 @@ def prepare(args):
             import yaml
 
             cfg = yaml.safe_load(f)
-            lg.warn(
+            lg.warning(
                 "NOTE: yaml has beed deprecated and will be remove on the next major release."
             )
         else:

--- a/pyaptly/publish.py
+++ b/pyaptly/publish.py
@@ -89,8 +89,8 @@ def publish_cmd_update(cfg, publish_name, publish_config, ignore_existing=False)
     # TODO: Fail gracefully and show an error when there is no existing publish
     try:
         current_snapshots = state_reader.state_reader().publish_map()[publish_fullname]
-    except KeyError as e:
-        util.exit_with_error("The publish hasn't been created yet: " + e)
+    except KeyError: # pragma: no cover
+        util.exit_with_error(f"The publish {publish_fullname} hasn't been created yet.")
     if "snapshots" in publish_config:
         snapshots_config = publish_config["snapshots"]
         new_snapshots = [

--- a/pyaptly/publish.py
+++ b/pyaptly/publish.py
@@ -140,7 +140,7 @@ def publish_cmd_update(cfg, publish_name, publish_config, ignore_existing=False)
                         current_snapshot = snap_name
                         break
                 if current_snapshot is None:
-                    lg.warn("Snapshot %s doesn't exist on to-be archived publish %s." % (snap["name"], publish_fullname))
+                    lg.warning("Snapshot %s doesn't exist on to-be archived publish %s." % (snap["name"], publish_fullname))
                 else:
                     snapshot.clone_snapshot(current_snapshot, archive).execute()
 

--- a/pyaptly/publish.py
+++ b/pyaptly/publish.py
@@ -139,8 +139,8 @@ def publish_cmd_update(cfg, publish_name, publish_config, ignore_existing=False)
                         break
                 if current_snapshot is None:
                     lg.warn("Snapshot %s doesn't exist on to-be archived publish %s." % (snap["name"], publish_fullname))
-
-                snapshot.clone_snapshot(current_snapshot, archive).execute()
+                else:
+                    snapshot.clone_snapshot(current_snapshot, archive).execute()
 
     publish_cmd.append("switch")
     options.append("-component=%s" % ",".join(components))

--- a/pyaptly/publish.py
+++ b/pyaptly/publish.py
@@ -85,10 +85,12 @@ def publish_cmd_update(cfg, publish_name, publish_config, ignore_existing=False)
         return cmd
 
     publish_fullname = "%s %s" % (publish_name, publish_config["distribution"])
-    # This line might fail if no publish has been created yet
-    # TODO: add clag --create to create publishes when they haven't been created yet
+    # TODO: add flag --create to create publishes when they haven't been created yet
     # TODO: Fail gracefully and show an error when there is no existing publish
-    current_snapshots = state_reader.state_reader().publish_map()[publish_fullname]
+    try:
+        current_snapshots = state_reader.state_reader().publish_map()[publish_fullname]
+    except KeyError as e:
+        util.exit_with_error("The publish hasn't been created yet: " + e)
     if "snapshots" in publish_config:
         snapshots_config = publish_config["snapshots"]
         new_snapshots = [

--- a/pyaptly/tests/publish-bad.toml
+++ b/pyaptly/tests/publish-bad.toml
@@ -1,0 +1,43 @@
+[[publish.fakerepo01]]
+gpg-key = "6D79A810B9B7ABAE"
+skip-contents = true
+automatic-update = true
+components = "main"
+distribution = "main"
+snapshots = [
+    { name = "fakerepo02-%T", timestamp = "current", archive-on-update = "archived-fakerepo01-%T" },
+]
+
+[[publish.fakerepo02]]
+gpg-key = "6D79A810B9B7ABAE"
+automatic-update = true
+components = "main"
+distribution = "main"
+snapshots = [
+    { name = "fakerepo01-%T", timestamp = "current", archive-on-update = "archived-fakerepo02-%T" },
+]
+
+[mirror.fakerepo01]
+max-tries = 2
+archive = "http://localhost:3123/fakerepo01"
+gpg-keys = [
+    "2841988729C7F3FF",
+]
+components = "main"
+distribution = "main"
+
+[mirror.fakerepo02]
+archive = "http://localhost:3123/fakerepo02"
+gpg-keys = [
+    "2841988729C7F3FF",
+]
+components = "main"
+distribution = "main"
+
+[snapshot."fakerepo01-%T"]
+mirror = "fakerepo01"
+timestamp = { time = "00:00" }
+
+[snapshot."fakerepo02-%T"]
+mirror = "fakerepo02"
+timestamp = { time = "00:00", repeat-weekly = "sat" }

--- a/pyaptly/tests/test_publish.py
+++ b/pyaptly/tests/test_publish.py
@@ -155,7 +155,7 @@ def test_publish_update_republish(config, publish_create_republish, freeze):
 
 
 @pytest.mark.parametrize("config", ["publish.toml"], indirect=True)
-def test_publish_updating_basic(config, publish_create, freeze):
+def test_publish_update_basic(config, publish_create, freeze):
     """Test if updating publishes works."""
     freeze.move_to("2012-10-11 10:10:10")
     args = ["-c", config, "snapshot", "create"]

--- a/pyaptly/tests/test_publish.py
+++ b/pyaptly/tests/test_publish.py
@@ -191,3 +191,28 @@ def test_repo_create_single(config, repo, test_key_03):
     main.main(args)
     state = state_reader.SystemStateReader()
     assert set(["centrify"]) == state.repos()
+
+
+@pytest.mark.parametrize("config", ["publish.toml"], indirect=True)
+def test_publish_update_wrong_snapshots(config, publish_create, freeze):
+    """Test if updating publishes works when the snapshot history is wrong."""
+    freeze.move_to("2012-10-11 10:10:10")
+    args = ["-c", config, "snapshot", "create"]
+    main.main(args)
+    args = ["-c", config.replace('.toml','-bad.toml'), "publish", "update"]
+    main.main(args)
+    state = state_reader.SystemStateReader()
+    expect = set(
+        [
+            "fakerepo01-20121011T0000Z",
+            "fakerepo02-20121006T0000Z",
+            "fakerepo01-20121010T0000Z",
+        ]
+    )
+    assert expect == state.snapshots()
+    # Reversed!
+    expect2 = {
+        "fakerepo01 main": set(["fakerepo02-20121006T0000Z"]),
+        "fakerepo02 main": set(["fakerepo01-20121011T0000Z"]),
+    }
+    assert expect2 == state.publish_map()


### PR DESCRIPTION
There was just an ugly stack trace and pyaptly aborted. Now it just says that it wanted to archive a snapshot for a publish which wasn't there.
I also added a comment in preparation for an additional feature I'm planning to be able to run `pyaptly update CONFIG --create`. Also, something we ran into several times.
It currently requires a bash script that runs the proper `snapshot create; snapshot update; publish create; publish update` sequence which is a bit of an annoyance.