### PR TITLE
Basic support for flat repositories

### DIFF
--- a/pyaptly/mirror.py
+++ b/pyaptly/mirror.py
@@ -133,7 +133,8 @@ def cmd_mirror_create(cfg, mirror_name, mirror_config):
     aptly_cmd.append(mirror_name)
     aptly_cmd.append(mirror_config["archive"])
     aptly_cmd.append(mirror_config["distribution"])
-    aptly_cmd.extend(util.unit_or_list_to_list(mirror_config["components"]))
+    if "components" in mirror_config:
+        aptly_cmd.extend(util.unit_or_list_to_list(mirror_config["components"]))
 
     cmd = command.Command(aptly_cmd)
     cmd.provide("mirror", mirror_name)


### PR DESCRIPTION
Hi, this PR makes a follow up on the following issue : #123 
This brings basic flat repository support without disturbing too much the rest of the `aptly_cmd` construction : 
If the `components` field is missing from the [mirror] definition in the TOML file, we simply do not add the argument, that way we avoid the ghost argument that was creating the issue described.

Please let me me know if I could help furterer in the support of flat repositories!